### PR TITLE
Fixed if condition to get a True when expected.

### DIFF
--- a/isfreader/py_isfreader.py
+++ b/isfreader/py_isfreader.py
@@ -108,7 +108,7 @@ def split_isf_header(data):
     # Get the index for splitting the header from the data
     curve = b':CURV'
     find = data.find(curve)
-    if data[find+len(curve)] == b'E':
+    if data[find+len(curve)] == b'E'[0]:
         length = len(b':CURVE #')
     elif find != -1:
         length = len(b':CURV #')


### PR DESCRIPTION
Indexing a byte array like `data` returns an `int` so when comparing equality with `b'E'` we always get `False` since the latter is a byte array. Indexing `b'E'` converts it to an int and fixes the comparison. 